### PR TITLE
Coverage: Full Hash Implementation

### DIFF
--- a/branta/Automations/Helpers/Wallets/Sparrow.swift
+++ b/branta/Automations/Helpers/Wallets/Sparrow.swift
@@ -18,8 +18,7 @@ class Sparrow: Wallet {
     
     override class func x86() -> [String:String] {
         return [
-            "1.8.2":"c82536ca87e8e40184be6cec4f64bea60666573428c41f6d004342445733b41f",
-            "1.8.2": "",
+            "1.8.2":"d963628ea41c2c3338fdd91aba22ac34d287f7fe0f717b2d0343f85c72f6439d", // Full hash
             "1.8.1":"a35554c23d8e324f8e4226e15ad0b6d4a71da4f47c5a219b6b1b395472f57422",
             "1.8.0":"cd4ed0b38d94d6a9fb32effa0ee1700eed4cfc6306fd3c29cd87637b7a40519e",
             "1.7.9":"ba0c91af54e327a3acb9f3afc61aed19f2321c73e5a6a7733292727201d3a9c6",

--- a/branta/Automations/Helpers/Wallets/Sparrow.swift
+++ b/branta/Automations/Helpers/Wallets/Sparrow.swift
@@ -19,6 +19,7 @@ class Sparrow: Wallet {
     override class func x86() -> [String:String] {
         return [
             "1.8.2":"c82536ca87e8e40184be6cec4f64bea60666573428c41f6d004342445733b41f",
+            "1.8.2": "",
             "1.8.1":"a35554c23d8e324f8e4226e15ad0b6d4a71da4f47c5a219b6b1b395472f57422",
             "1.8.0":"cd4ed0b38d94d6a9fb32effa0ee1700eed4cfc6306fd3c29cd87637b7a40519e",
             "1.7.9":"ba0c91af54e327a3acb9f3afc61aed19f2321c73e5a6a7733292727201d3a9c6",
@@ -125,36 +126,3 @@ class Sparrow: Wallet {
         ]
     }
 }
-
-
-
-/*
- Sparrow links out to many libs. We could hash all of these as well.
- $ ls -lh *.dylib
- -rw-r--r--@ 1 keithgardner  admin   632K Nov 22 03:53 libawt.dylib
- -rw-r--r--@ 1 keithgardner  admin   1.1M Nov 22 03:53 libawt_lwawt.dylib
- -rw-r--r--@ 1 keithgardner  admin   1.6M Nov 22 03:53 libfontmanager.dylib
- -rw-r--r--@ 1 keithgardner  admin   664K Nov 22 03:53 libfreetype.dylib
- -rw-r--r--@ 1 keithgardner  admin    37K Nov 22 03:53 libj2pcsc.dylib
- -rw-r--r--@ 1 keithgardner  admin    95K Nov 22 03:53 libj2pkcs11.dylib
- -rw-r--r--@ 1 keithgardner  admin   171K Nov 22 03:53 libjava.dylib
- -rw-r--r--@ 1 keithgardner  admin   247K Nov 22 03:53 libjavajpeg.dylib
- -rw-r--r--@ 1 keithgardner  admin    27K Nov 22 03:53 libjawt.dylib
- -rw-r--r--@ 1 keithgardner  admin    47K Nov 22 03:53 libjimage.dylib
- -rw-r--r--@ 1 keithgardner  admin    83K Nov 22 03:53 libjli.dylib
- -rw-r--r--@ 1 keithgardner  admin    28K Nov 22 03:53 libjsig.dylib
- -rw-r--r--@ 1 keithgardner  admin   104K Nov 22 03:53 libjsound.dylib
- -rw-r--r--@ 1 keithgardner  admin   426K Nov 22 03:53 liblcms.dylib
- -rw-r--r--@ 1 keithgardner  admin    38K Nov 22 03:53 libmanagement.dylib
- -rw-r--r--@ 1 keithgardner  admin   620K Nov 22 03:53 libmlib_image.dylib
- -rw-r--r--@ 1 keithgardner  admin    77K Nov 22 03:53 libnet.dylib
- -rw-r--r--@ 1 keithgardner  admin    83K Nov 22 03:53 libnio.dylib
- -rw-r--r--@ 1 keithgardner  admin    39K Nov 22 03:53 libosx.dylib
- -rw-r--r--@ 1 keithgardner  admin   148K Nov 22 03:53 libosxapp.dylib
- -rw-r--r--@ 1 keithgardner  admin    40K Nov 22 03:53 libosxsecurity.dylib
- -rw-r--r--@ 1 keithgardner  admin    58K Nov 22 03:53 libosxui.dylib
- -rw-r--r--@ 1 keithgardner  admin    44K Nov 22 03:53 libprefs.dylib
- -rw-r--r--@ 1 keithgardner  admin   376K Nov 22 03:53 libsplashscreen.dylib
- -rw-r--r--@ 1 keithgardner  admin    71K Nov 22 03:53 libverify.dylib
- -rw-r--r--@ 1 keithgardner  admin    53K Nov 22 03:53 libzip.dylib
- */

--- a/branta/Automations/Verify.swift
+++ b/branta/Automations/Verify.swift
@@ -152,14 +152,11 @@ class Verify: Automation {
                         exePath = String(item.dropLast(4))
                     }
                     
-                    let pathToExe = PATH + "/" + item + "/Contents/MacOS/" + exePath
-                    let exeHash = sha256(at: pathToExe)
-                    
-                    let dir = PATH + "/" + item
-                    let dirHash = sha256ForDirectory(atPath: dir)
-
-                    
-                    let version = getAppVersion(atPath: (PATH + "/" + item))
+                    let dir         = PATH + "/" + item
+                    let pathToExe   = dir + "/Contents/MacOS/" + exePath
+                    let exeHash     = sha256(at: pathToExe)
+                    let dirHash     = sha256ForDirectory(atPath: dir)
+                    let version     = getAppVersion(atPath: (dir))
                     
                     let r = [
                         "name": item,
@@ -167,8 +164,9 @@ class Verify: Automation {
                         "hash": exeHash,
                         "match": "false",
                         "version": version,
-                        "dirHash": dirHash != nil ? dirHash! : ""
+                        "dirHash": dirHash != nil ? dirHash! : "" // TODO - hook here
                     ]
+                    
                     ret.append(r)
                 }
             }

--- a/branta/Automations/Verify.swift
+++ b/branta/Automations/Verify.swift
@@ -52,7 +52,6 @@ class Verify: Automation {
     
     static func verify() {
         let wallets = crawlWallets()
-        print("wallets: \(wallets)")
         signatures = matchSignatures(wallets: wallets)
     }
     
@@ -64,10 +63,7 @@ class Verify: Automation {
             exePath = TARGETS[wallet + ".app"]!.CFBundleExecutable()
         }
         
-        
         let fullPath = PATH + "/" + wallet + ".app/Contents/MacOS/" + exePath
-        
-        print("fullPath: \(fullPath)")
         let hash = sha256(at: fullPath)
 
         return HashGrabber.runtimeHashMatches(hash: hash, wallet: "\(wallet).app")
@@ -156,23 +152,24 @@ class Verify: Automation {
                         exePath = String(item.dropLast(4))
                     }
                     
-                    let fullPath = PATH + "/" + item + "/Contents/MacOS/" + exePath
-                    let fullPathHash = sha256(at: fullPath)
+                    let pathToExe = PATH + "/" + item + "/Contents/MacOS/" + exePath
+                    let exeHash = sha256(at: pathToExe)
                     
-                    let entryPoint = PATH + "/" + item
-                    let entryPointHash = sha256ForDirectory(atPath: entryPoint)
+                    let dir = PATH + "/" + item
+                    let dirHash = sha256ForDirectory(atPath: dir)
 
                     
                     let version = getAppVersion(atPath: (PATH + "/" + item))
                     
-                    ret.append([
+                    let r = [
                         "name": item,
-                        "path": fullPath,
-                        "hash": fullPathHash,
+                        "path": pathToExe,
+                        "hash": exeHash,
                         "match": "false",
                         "version": version,
-                        "entryPointHash": entryPointHash != nil ? entryPointHash! : ""
-                    ])
+                        "dirHash": dirHash != nil ? dirHash! : ""
+                    ]
+                    ret.append(r)
                 }
             }
             return ret

--- a/branta/Automations/Verify.swift
+++ b/branta/Automations/Verify.swift
@@ -52,6 +52,7 @@ class Verify: Automation {
     
     static func verify() {
         let wallets = crawlWallets()
+        print("wallets: \(wallets)")
         signatures = matchSignatures(wallets: wallets)
     }
     
@@ -63,7 +64,10 @@ class Verify: Automation {
             exePath = TARGETS[wallet + ".app"]!.CFBundleExecutable()
         }
         
+        
         let fullPath = PATH + "/" + wallet + ".app/Contents/MacOS/" + exePath
+        
+        print("fullPath: \(fullPath)")
         let hash = sha256(at: fullPath)
 
         return HashGrabber.runtimeHashMatches(hash: hash, wallet: "\(wallet).app")
@@ -153,15 +157,21 @@ class Verify: Automation {
                     }
                     
                     let fullPath = PATH + "/" + item + "/Contents/MacOS/" + exePath
-                    let hash = sha256(at: fullPath)
+                    let fullPathHash = sha256(at: fullPath)
+                    
+                    let entryPoint = PATH + "/" + item
+                    let entryPointHash = sha256ForDirectory(atPath: entryPoint)
+
+                    
                     let version = getAppVersion(atPath: (PATH + "/" + item))
                     
                     ret.append([
                         "name": item,
                         "path": fullPath,
-                        "hash": hash,
+                        "hash": fullPathHash,
                         "match": "false",
-                        "version": version
+                        "version": version,
+                        "entryPointHash": entryPointHash != nil ? entryPointHash! : ""
                     ])
                 }
             }

--- a/branta/Utils/Sha.swift
+++ b/branta/Utils/Sha.swift
@@ -21,6 +21,36 @@ func sha256(at filePath: String) -> String {
     }
 }
 
+func sha256ForDirectory(atPath path: String) -> String? {
+    var concatenatedHashes = ""
+
+    let fileManager = FileManager.default
+
+    guard let enumerator = fileManager.enumerator(atPath: path) else {
+        return nil
+    }
+
+    for case let fileURL as URL in enumerator {
+        do {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
+            if resourceValues.isRegularFile ?? false {
+                let hash = sha256(at: fileURL.path)
+                concatenatedHashes += hash
+            }
+        } catch {
+            print("Error accessing file: \(fileURL.path), error: \(error)")
+        }
+    }
+
+    // Hash the concatenated hashes
+    if let data = concatenatedHashes.data(using: .utf8) {
+        let hashed = SHA256.hash(data: data)
+        return hashed.compactMap { String(format: "%02x", $0) }.joined()
+    } else {
+        return nil
+    }
+}
+
 func sha512(at filePath: String) -> String {
     do {
         let data = try Data(contentsOf: URL(fileURLWithPath: filePath))

--- a/branta/Utils/Sha.swift
+++ b/branta/Utils/Sha.swift
@@ -8,24 +8,23 @@
 import CryptoKit
 import Foundation
 
-
 func sha256(at filePath: String) -> String {
     do {
         let data = try Data(contentsOf: URL(fileURLWithPath: filePath))
         let hashed = SHA256.hash(data: data)
         return hashed.compactMap { String(format: "%02x", $0) }.joined()
     } catch {
-        // TODO - need handling
         print("sha256() Error reading file: \(error)")
         return ""
     }
 }
 
-// 1. Traverse file dir and hash entire set
+// 1. Traverse directory, skip symlinks, hash files
 // 2. Combine hashes
 // 3. SHA256 the combined hashes
 func sha256ForDirectory(atPath path: String) -> String? {
     var concatenatedHashes = ""
+    
     let fileManager = FileManager.default
     guard let enumerator = fileManager.enumerator(atPath: path) else {
         return nil
@@ -33,14 +32,14 @@ func sha256ForDirectory(atPath path: String) -> String? {
 
     for e in enumerator {
         do {
-            if let item = e as? String {
-                let fullPath = path + "/" + item
+            if let node = e as? String {
+                let fullPath = path + "/" + node
 
                 let isDirectory = (enumerator.fileAttributes?[.type] as? FileAttributeType) == .typeDirectory
                 let isSymLink = (enumerator.fileAttributes?[.type] as? FileAttributeType) == .typeSymbolicLink
                 
                 if !isDirectory && !isSymLink {
-                    print("Hashed: \(fullPath)")
+                    print("Hashing: \(fullPath)")
                     let hash = sha256(at: fullPath)
                     concatenatedHashes += hash
                 }
@@ -64,7 +63,6 @@ func sha512(at filePath: String) -> String {
         let hashed = SHA512.hash(data: data)
         return hashed.compactMap { String(format: "%02x", $0) }.joined()
     } catch {
-        // TODO - need handling
         print("sha256() Error reading file: \(error)")
         return ""
     }


### PR DESCRIPTION
Full Sparrow 1.8.2 Tree:

```
Contents/_CodeSignature
Contents/_CodeSignature/CodeResources
Contents/MacOS
Contents/MacOS/Sparrow
Contents/app
Contents/app/.jpackage.xml
Contents/app/Sparrow.cfg
Contents/Resources
Contents/Resources/Sparrow.icns
Contents/runtime
Contents/runtime/Contents
Contents/runtime/Contents/_CodeSignature
Contents/runtime/Contents/_CodeSignature/CodeResources
Contents/runtime/Contents/Home
Contents/runtime/Contents/Home/bin
Contents/runtime/Contents/Home/bin/sparrow
Contents/runtime/Contents/Home/bin/sparrow.bat
Contents/runtime/Contents/Home/release
Contents/runtime/Contents/Home/lib
Contents/runtime/Contents/Home/lib/libnet.dylib
Contents/runtime/Contents/Home/lib/libnio.dylib
Contents/runtime/Contents/Home/lib/libzip.dylib
Contents/runtime/Contents/Home/lib/psfontj2d.properties
Contents/runtime/Contents/Home/lib/fontconfig.properties.src
Contents/runtime/Contents/Home/lib/libfreetype.dylib
Contents/runtime/Contents/Home/lib/libjli.dylib
Contents/runtime/Contents/Home/lib/libsplashscreen.dylib
Contents/runtime/Contents/Home/lib/libj2pkcs11.dylib
Contents/runtime/Contents/Home/lib/jvm.cfg
Contents/runtime/Contents/Home/lib/libjimage.dylib
Contents/runtime/Contents/Home/lib/security
Contents/runtime/Contents/Home/lib/security/public_suffix_list.dat
Contents/runtime/Contents/Home/lib/security/default.policy
Contents/runtime/Contents/Home/lib/security/cacerts
Contents/runtime/Contents/Home/lib/security/blocked.certs
Contents/runtime/Contents/Home/lib/shaders.metallib
Contents/runtime/Contents/Home/lib/libosxui.dylib
Contents/runtime/Contents/Home/lib/tzdb.dat
Contents/runtime/Contents/Home/lib/libawt_lwawt.dylib
Contents/runtime/Contents/Home/lib/server
Contents/runtime/Contents/Home/lib/server/libjvm.dylib
Contents/runtime/Contents/Home/lib/server/libjsig.dylib
Contents/runtime/Contents/Home/lib/libjavajpeg.dylib
Contents/runtime/Contents/Home/lib/libmlib_image.dylib
Contents/runtime/Contents/Home/lib/libmanagement.dylib
Contents/runtime/Contents/Home/lib/libjsound.dylib
Contents/runtime/Contents/Home/lib/libj2pcsc.dylib
Contents/runtime/Contents/Home/lib/libjsig.dylib
Contents/runtime/Contents/Home/lib/libprefs.dylib
Contents/runtime/Contents/Home/lib/libjawt.dylib
Contents/runtime/Contents/Home/lib/jrt-fs.jar
Contents/runtime/Contents/Home/lib/libfontmanager.dylib
Contents/runtime/Contents/Home/lib/fontconfig.bfc
Contents/runtime/Contents/Home/lib/jspawnhelper
Contents/runtime/Contents/Home/lib/libosxsecurity.dylib
Contents/runtime/Contents/Home/lib/liblcms.dylib
Contents/runtime/Contents/Home/lib/libverify.dylib
Contents/runtime/Contents/Home/lib/psfont.properties.ja
Contents/runtime/Contents/Home/lib/modules
Contents/runtime/Contents/Home/lib/classlist
Contents/runtime/Contents/Home/lib/libjava.dylib
Contents/runtime/Contents/Home/lib/libawt.dylib
Contents/runtime/Contents/Home/lib/libosx.dylib
Contents/runtime/Contents/Home/lib/libosxapp.dylib
Contents/runtime/Contents/Home/legal
Contents/runtime/Contents/Home/legal/jdk.unsupported.desktop
Contents/runtime/Contents/Home/legal/jdk.unsupported.desktop/LICENSE
Contents/runtime/Contents/Home/legal/jdk.unsupported.desktop/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/jdk.unsupported.desktop/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.management
Contents/runtime/Contents/Home/legal/java.management/LICENSE
Contents/runtime/Contents/Home/legal/java.management/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.management/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.security.sasl
Contents/runtime/Contents/Home/legal/java.security.sasl/LICENSE
Contents/runtime/Contents/Home/legal/java.security.sasl/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.security.sasl/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.xml
Contents/runtime/Contents/Home/legal/java.xml/bcel.md
Contents/runtime/Contents/Home/legal/java.xml/LICENSE
Contents/runtime/Contents/Home/legal/java.xml/xalan.md
Contents/runtime/Contents/Home/legal/java.xml/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.xml/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.xml/dom.md
Contents/runtime/Contents/Home/legal/java.xml/jcup.md
Contents/runtime/Contents/Home/legal/java.xml/xerces.md
Contents/runtime/Contents/Home/legal/java.prefs
Contents/runtime/Contents/Home/legal/java.prefs/LICENSE
Contents/runtime/Contents/Home/legal/java.prefs/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.prefs/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/jdk.crypto.cryptoki
Contents/runtime/Contents/Home/legal/jdk.crypto.cryptoki/LICENSE
Contents/runtime/Contents/Home/legal/jdk.crypto.cryptoki/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/jdk.crypto.cryptoki/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/jdk.crypto.cryptoki/pkcs11wrapper.md
Contents/runtime/Contents/Home/legal/jdk.crypto.cryptoki/pkcs11cryptotoken.md
Contents/runtime/Contents/Home/legal/java.logging
Contents/runtime/Contents/Home/legal/java.logging/LICENSE
Contents/runtime/Contents/Home/legal/java.logging/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.logging/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.base
Contents/runtime/Contents/Home/legal/java.base/asm.md
Contents/runtime/Contents/Home/legal/java.base/LICENSE
Contents/runtime/Contents/Home/legal/java.base/public_suffix.md
Contents/runtime/Contents/Home/legal/java.base/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.base/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.base/cldr.md
Contents/runtime/Contents/Home/legal/java.base/icu.md
Contents/runtime/Contents/Home/legal/java.base/unicode.md
Contents/runtime/Contents/Home/legal/java.base/c-libutl.md
Contents/runtime/Contents/Home/legal/java.base/aes.md
Contents/runtime/Contents/Home/legal/java.net.http
Contents/runtime/Contents/Home/legal/java.net.http/LICENSE
Contents/runtime/Contents/Home/legal/java.net.http/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.net.http/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.naming
Contents/runtime/Contents/Home/legal/java.naming/LICENSE
Contents/runtime/Contents/Home/legal/java.naming/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.naming/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/jdk.unsupported
Contents/runtime/Contents/Home/legal/jdk.unsupported/LICENSE
Contents/runtime/Contents/Home/legal/jdk.unsupported/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/jdk.unsupported/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.scripting
Contents/runtime/Contents/Home/legal/java.scripting/LICENSE
Contents/runtime/Contents/Home/legal/java.scripting/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.scripting/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.smartcardio
Contents/runtime/Contents/Home/legal/java.smartcardio/LICENSE
Contents/runtime/Contents/Home/legal/java.smartcardio/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.smartcardio/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.smartcardio/pcsclite.md
Contents/runtime/Contents/Home/legal/java.transaction.xa
Contents/runtime/Contents/Home/legal/java.transaction.xa/LICENSE
Contents/runtime/Contents/Home/legal/java.transaction.xa/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.transaction.xa/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.sql
Contents/runtime/Contents/Home/legal/java.sql/LICENSE
Contents/runtime/Contents/Home/legal/java.sql/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.sql/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.datatransfer
Contents/runtime/Contents/Home/legal/java.datatransfer/LICENSE
Contents/runtime/Contents/Home/legal/java.datatransfer/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.datatransfer/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.desktop
Contents/runtime/Contents/Home/legal/java.desktop/freetype.md
Contents/runtime/Contents/Home/legal/java.desktop/mesa3d.md
Contents/runtime/Contents/Home/legal/java.desktop/colorimaging.md
Contents/runtime/Contents/Home/legal/java.desktop/LICENSE
Contents/runtime/Contents/Home/legal/java.desktop/libpng.md
Contents/runtime/Contents/Home/legal/java.desktop/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/java.desktop/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/legal/java.desktop/xwd.md
Contents/runtime/Contents/Home/legal/java.desktop/giflib.md
Contents/runtime/Contents/Home/legal/java.desktop/harfbuzz.md
Contents/runtime/Contents/Home/legal/java.desktop/jpeg.md
Contents/runtime/Contents/Home/legal/java.desktop/lcms.md
Contents/runtime/Contents/Home/legal/jdk.crypto.ec
Contents/runtime/Contents/Home/legal/jdk.crypto.ec/LICENSE
Contents/runtime/Contents/Home/legal/jdk.crypto.ec/ADDITIONAL_LICENSE_INFO
Contents/runtime/Contents/Home/legal/jdk.crypto.ec/ASSEMBLY_EXCEPTION
Contents/runtime/Contents/Home/conf
Contents/runtime/Contents/Home/conf/logging.properties
Contents/runtime/Contents/Home/conf/sound.properties
Contents/runtime/Contents/Home/conf/security
Contents/runtime/Contents/Home/conf/security/java.security
Contents/runtime/Contents/Home/conf/security/java.policy
Contents/runtime/Contents/Home/conf/security/policy
Contents/runtime/Contents/Home/conf/security/policy/unlimited
Contents/runtime/Contents/Home/conf/security/policy/unlimited/default_US_export.policy
Contents/runtime/Contents/Home/conf/security/policy/unlimited/default_local.policy
Contents/runtime/Contents/Home/conf/security/policy/README.txt
Contents/runtime/Contents/Home/conf/security/policy/limited
Contents/runtime/Contents/Home/conf/security/policy/limited/default_US_export.policy
Contents/runtime/Contents/Home/conf/security/policy/limited/exempt_local.policy
Contents/runtime/Contents/Home/conf/security/policy/limited/default_local.policy
Contents/runtime/Contents/Home/conf/net.properties
Contents/runtime/Contents/MacOS
Contents/runtime/Contents/MacOS/libjli.dylib
Contents/runtime/Contents/Info.plist
Contents/Info.plist
Contents/PkgInfo
```