### PR TITLE
Stub Last Scanned, Min size for Dropview

### DIFF
--- a/branta/Base.lproj/Main.storyboard
+++ b/branta/Base.lproj/Main.storyboard
@@ -737,14 +737,14 @@
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView appearanceType="darkAqua" verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="plain" selectionHighlightStyle="none" alternatingRowBackgroundColors="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="30" rowSizeStyle="automatic" headerView="doB-w8-eVF" viewBased="YES" id="f7n-2h-iou">
-                                                    <rect key="frame" x="0.0" y="0.0" width="761" height="207"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="810" height="207"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="17" height="0.0"/>
                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                     <tableColumns>
-                                                        <tableColumn identifier="AutomaticTableColumnIdentifier.0" editable="NO" width="360" minWidth="40" maxWidth="1000" id="1u0-2u-1Kr">
-                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center">
+                                                        <tableColumn identifier="AutomaticTableColumnIdentifier.0" editable="NO" width="253" minWidth="40" maxWidth="1000" id="1u0-2u-1Kr">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="Wallet">
                                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                             </tableHeaderCell>
@@ -756,11 +756,11 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             <prototypeCellViews>
                                                                 <tableCellView identifier="foo" id="8Dp-CS-tBS">
-                                                                    <rect key="frame" x="8" y="0.0" width="360" height="30"/>
+                                                                    <rect key="frame" x="8" y="0.0" width="253" height="30"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PO4-RB-BF4">
-                                                                            <rect key="frame" x="0.0" y="7" width="360" height="16"/>
+                                                                            <rect key="frame" x="0.0" y="7" width="253" height="16"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="blah blah blah" id="Jay-Mb-UVI">
                                                                                 <font key="font" usesAppearanceFont="YES"/>
@@ -775,8 +775,8 @@
                                                                 </tableCellView>
                                                             </prototypeCellViews>
                                                         </tableColumn>
-                                                        <tableColumn identifier="AutomaticTableColumnIdentifier.1" width="367" minWidth="40" maxWidth="1000" id="LZl-05-DLb">
-                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center">
+                                                        <tableColumn identifier="AutomaticTableColumnIdentifier.1" width="253" minWidth="40" maxWidth="1000" id="LZl-05-DLb">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="Status">
                                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                             </tableHeaderCell>
@@ -788,11 +788,11 @@
                                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             <prototypeCellViews>
                                                                 <tableCellView id="fj6-TM-5zd">
-                                                                    <rect key="frame" x="385" y="0.0" width="367" height="30"/>
+                                                                    <rect key="frame" x="278" y="0.0" width="253" height="30"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                     <subviews>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RJU-2V-KUW">
-                                                                            <rect key="frame" x="0.0" y="7" width="367" height="16"/>
+                                                                            <rect key="frame" x="0.0" y="7" width="253" height="16"/>
                                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="baz" id="i5L-cG-S4z">
                                                                                 <font key="font" usesAppearanceFont="YES"/>
@@ -807,13 +807,45 @@
                                                                 </tableCellView>
                                                             </prototypeCellViews>
                                                         </tableColumn>
+                                                        <tableColumn identifier="AutomaticTableColumnIdentifier.2" width="253" minWidth="40" maxWidth="1000" id="VeT-ca-4dz">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="Last Scanned">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" title="Text Cell" id="Lk4-Qe-bXc">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <prototypeCellViews>
+                                                                <tableCellView id="oE5-nP-ilZ">
+                                                                    <rect key="frame" x="548" y="0.0" width="253" height="30"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                    <subviews>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hm2-XT-qi8">
+                                                                            <rect key="frame" x="0.0" y="7" width="253" height="16"/>
+                                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="baz" id="Zg4-TZ-M1M">
+                                                                                <font key="font" usesAppearanceFont="YES"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <connections>
+                                                                        <outlet property="textField" destination="hm2-XT-qi8" id="d0z-Qf-XCQ"/>
+                                                                    </connections>
+                                                                </tableCellView>
+                                                            </prototypeCellViews>
+                                                        </tableColumn>
                                                     </tableColumns>
                                                 </tableView>
                                             </subviews>
                                             <nil key="backgroundColor"/>
                                         </clipView>
-                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="1BG-6u-5MP">
-                                            <rect key="frame" x="1" y="233" width="713" height="16"/>
+                                        <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="1BG-6u-5MP">
+                                            <rect key="frame" x="0.0" y="219" width="761" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="Q7l-0S-uK3">
@@ -821,7 +853,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <tableHeaderView key="headerView" wantsLayer="YES" id="doB-w8-eVF">
-                                            <rect key="frame" x="0.0" y="0.0" width="761" height="28"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="810" height="28"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableHeaderView>
                                     </scrollView>
@@ -883,6 +915,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="dropView" destination="zbK-gp-Ps7" id="qAd-hv-L2n"/>
                         <outlet property="tableView" destination="f7n-2h-iou" id="AZn-N9-JPK"/>
                         <outlet property="walletsDetected" destination="ebA-yH-dzu" id="f4S-oD-DHf"/>
                     </connections>

--- a/branta/Base.lproj/Main.storyboard
+++ b/branta/Base.lproj/Main.storyboard
@@ -915,7 +915,6 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="dropView" destination="zbK-gp-Ps7" id="qAd-hv-L2n"/>
                         <outlet property="tableView" destination="f7n-2h-iou" id="AZn-N9-JPK"/>
                         <outlet property="walletsDetected" destination="ebA-yH-dzu" id="f4S-oD-DHf"/>
                     </connections>

--- a/branta/ViewControllers/BrantaViewController.swift
+++ b/branta/ViewControllers/BrantaViewController.swift
@@ -14,8 +14,6 @@ let TABLE_FONT = 17.0
 class BrantaViewController: NSViewController, VerifyObserver, NSTableViewDelegate, NSTableViewDataSource {
     @IBOutlet weak var walletsDetected: NSTextField!
     @IBOutlet weak var tableView: NSTableView!
-    @IBOutlet weak var dropView: DropView!
-    
     
     var tableData: Array<[String: String]> = []
     
@@ -27,7 +25,7 @@ class BrantaViewController: NSViewController, VerifyObserver, NSTableViewDelegat
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.delegate = self
-        tableView.dataSource = self        
+        tableView.dataSource = self
     }
     
     override func viewDidAppear() {
@@ -141,11 +139,18 @@ class BrantaViewController: NSViewController, VerifyObserver, NSTableViewDelegat
         }
     }
 
+    // Lets hide this... adds noise to homescreen
     func verifyDidChange(newResults: Array<[String: String]>) {
+        if newResults.count == 0 {
+            walletsDetected.isHidden = false
+            walletsDetected.stringValue = "0 Wallets Detected."
+        }
         if newResults.count == 1 {
+            walletsDetected.isHidden = true
             walletsDetected.stringValue = "1 Wallet Detected."
         }
         else {
+            walletsDetected.isHidden = true
             walletsDetected.stringValue = "\(newResults.count) Wallets Detected."
         }
         tableData = newResults

--- a/branta/ViewControllers/BrantaViewController.swift
+++ b/branta/ViewControllers/BrantaViewController.swift
@@ -77,14 +77,11 @@ class BrantaViewController: NSViewController, VerifyObserver, NSTableViewDelegat
             textField.font = NSFont(name: FONT, size: 20.0)
             let clickGesture = NSClickGestureRecognizer(target: self, action: #selector(showDetails))
             textField.addGestureRecognizer(clickGesture)
-        } else if columnNumber == 2 {
-            let currentTime = Date()
-
-            let dateFormatter = DateFormatter()
+        } else if columnNumber == 2 {            
+            let currentTime         = Date()
+            let dateFormatter       = DateFormatter()
             dateFormatter.timeStyle = .medium
-
-            let formattedTime = dateFormatter.string(from: currentTime)
-//            print("Current time is: \(formattedTime)")
+            let formattedTime       = dateFormatter.string(from: currentTime)
             
             textField.stringValue = formattedTime
         }

--- a/branta/ViewControllers/BrantaViewController.swift
+++ b/branta/ViewControllers/BrantaViewController.swift
@@ -14,6 +14,8 @@ let TABLE_FONT = 17.0
 class BrantaViewController: NSViewController, VerifyObserver, NSTableViewDelegate, NSTableViewDataSource {
     @IBOutlet weak var walletsDetected: NSTextField!
     @IBOutlet weak var tableView: NSTableView!
+    @IBOutlet weak var dropView: DropView!
+    
     
     var tableData: Array<[String: String]> = []
     
@@ -25,7 +27,7 @@ class BrantaViewController: NSViewController, VerifyObserver, NSTableViewDelegat
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.delegate = self
-        tableView.dataSource = self
+        tableView.dataSource = self        
     }
     
     override func viewDidAppear() {
@@ -77,6 +79,16 @@ class BrantaViewController: NSViewController, VerifyObserver, NSTableViewDelegat
             textField.font = NSFont(name: FONT, size: 20.0)
             let clickGesture = NSClickGestureRecognizer(target: self, action: #selector(showDetails))
             textField.addGestureRecognizer(clickGesture)
+        } else if columnNumber == 2 {
+            let currentTime = Date()
+
+            let dateFormatter = DateFormatter()
+            dateFormatter.timeStyle = .medium
+
+            let formattedTime = dateFormatter.string(from: currentTime)
+//            print("Current time is: \(formattedTime)")
+            
+            textField.stringValue = formattedTime
         }
         return textField
     }

--- a/branta/Views/DropView.swift
+++ b/branta/Views/DropView.swift
@@ -25,6 +25,9 @@ class DropView: NSView {
     ]
     let LIVE_COLOR = NSColor.darkGray.cgColor
     let IDLE_COLOR = NSColor(hex: GRAY)?.cgColor
+    
+    let minimumHeight: CGFloat = 100
+    let minimumWidth: CGFloat = 200
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -33,6 +36,14 @@ class DropView: NSView {
         self.layer?.backgroundColor = IDLE_COLOR
 
         registerForDraggedTypes([NSPasteboard.PasteboardType.URL, NSPasteboard.PasteboardType.fileURL])
+    }
+    
+    
+    override var intrinsicContentSize: NSSize {
+        var size = super.intrinsicContentSize
+        size.width = max(size.width, minimumWidth)
+        size.height = max(size.height, minimumHeight)
+        return size
     }
 
     override func draw(_ dirtyRect: NSRect) {


### PR DESCRIPTION
- Show timestamps of last scan per wallet
- Enforce minimum size on DropView
- Remove "2 Wallets Detected?" and only keep when 0 wallets are detected

<img width="862" alt="Screen Shot 2024-02-23 at 10 20 45 AM" src="https://github.com/BrantaOps/branta-mac/assets/74844722/4987ed28-12db-4928-bc66-355e516ed96c">

Without "2 Wallets Detected"
<img width="862" alt="Screen Shot 2024-02-23 at 10 28 00 AM" src="https://github.com/BrantaOps/branta-mac/assets/74844722/2ed5a321-8bb3-46ce-b2a3-135c90c60f35">

Min size:

<img width="512" alt="Screen Shot 2024-02-23 at 10 42 26 AM" src="https://github.com/BrantaOps/branta-mac/assets/74844722/30b1af23-f8e3-4881-bf35-c414d16ec665">

